### PR TITLE
Make deployer work for SCDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<kubernetes-client.version>1.3.63</kubernetes-client.version>
-		<kubernetes-assertions.version>2.2.76</kubernetes-assertions.version>
+		<kubernetes-client.version>1.3.82</kubernetes-client.version>
+		<kubernetes-assertions.version>2.2.101</kubernetes-assertions.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -17,12 +17,14 @@
 package org.springframework.cloud.deployer.spi.kubernetes;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HTTPGetActionBuilder;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
@@ -61,8 +63,17 @@ public class DefaultContainerFactory implements ContainerFactory {
 			throw new IllegalArgumentException("Unable to get URI for " + request.getResource(), e);
 		}
 		logger.info("Using Docker image: " + image);
+
+		//TODO: make this configurable!
+		List<EnvVar> envVars = new ArrayList<>();
+		envVars.add(new EnvVar("SPRING_RABBITMQ_HOST", "${RABBITMQ_SERVICE_HOST}", null));
+		envVars.add(new EnvVar("SPRING_RABBITMQ_PORT", "${RABBITMQ_SERVICE_PORT}", null));
+		envVars.add(new EnvVar("SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS", "${KAFKA_SERVICE_HOST}:${KAFKA_SERVICE_PORT}", null));
+		envVars.add(new EnvVar("SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES", "${ZK_SERVICE_HOST}:${ZK_SERVICE_PORT}", null));
+
 		container.withName(appId)
 				.withImage(image)
+				.withEnv(envVars)
 				.withArgs(createCommandArgs(request))
 				.addNewPort()
 					.withContainerPort(port)

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -90,7 +90,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 	/**
 	 * Create a readiness probe for the /health endpoint exposed by each module.
 	 */
-	protected Probe createProbe(Integer externalPort, long timeout, long initialDelay) {
+	protected Probe createProbe(Integer externalPort, int timeout, int initialDelay) {
 		return new ProbeBuilder()
 			.withHttpGet(
 				new HTTPGetActionBuilder()

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.util.Assert;
 
 /**
  * Create a Kubernetes {@link Container} that will be started as part of a
@@ -64,12 +65,12 @@ public class DefaultContainerFactory implements ContainerFactory {
 		}
 		logger.info("Using Docker image: " + image);
 
-		//TODO: make this configurable!
 		List<EnvVar> envVars = new ArrayList<>();
-		envVars.add(new EnvVar("SPRING_RABBITMQ_HOST", "${RABBITMQ_SERVICE_HOST}", null));
-		envVars.add(new EnvVar("SPRING_RABBITMQ_PORT", "${RABBITMQ_SERVICE_PORT}", null));
-		envVars.add(new EnvVar("SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS", "${KAFKA_SERVICE_HOST}:${KAFKA_SERVICE_PORT}", null));
-		envVars.add(new EnvVar("SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES", "${ZK_SERVICE_HOST}:${ZK_SERVICE_PORT}", null));
+		for (String envVar : properties.getEnvironmentVariables()) {
+			String[] strings = envVar.split("=", 2);
+			Assert.isTrue(strings.length == 2, "Invalid environment variable declared: " + envVar);
+			envVars.add(new EnvVar(strings[0], strings[1], null));
+		}
 
 		container.withName(appId)
 				.withImage(image)

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
@@ -246,11 +247,11 @@ public class KubernetesAppDeployer implements AppDeployer {
 	}
 
 	private Map<String, Quantity> deduceResourceLimits(AppDeploymentRequest request) {
-		String memOverride = request.getDefinition().getProperties().get("kubernetes.memory");
+		String memOverride = request.getEnvironmentProperties().get("spring.cloud.deployer.kubernetes.memory");
 		if (memOverride == null)
 			memOverride = properties.getMemory();
 
-		String cpuOverride = request.getDefinition().getProperties().get("kubernetes.cpu");
+		String cpuOverride = request.getEnvironmentProperties().get("spring.cloud.deployer.kubernetes.cpu");
 		if (cpuOverride == null)
 			cpuOverride = properties.getCpu();
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -116,7 +116,8 @@ public class KubernetesAppDeployer implements AppDeployer {
 			if ("LoadBalancer".equals(client.services().withName(appId).get().getSpec().getType())) {
 				Service svc = client.services().withName(appId).get();
 				int tries = 0;
-				while (tries++ < 30) {
+				int maxWait = properties.getMinutesToWaitForLoadBalancer() * 6; // we check 6 times per minute
+				while (tries++ < maxWait) {
 					if (svc.getStatus().getLoadBalancer() != null &&
 							svc.getStatus().getLoadBalancer().getIngress() != null &&
 							svc.getStatus().getLoadBalancer().getIngress().isEmpty()) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -30,6 +30,8 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
@@ -108,17 +110,37 @@ public class KubernetesAppDeployer implements AppDeployer {
 
 
 	@Override
-	public void undeploy(String id) {
-
-		String appId = fixKubeId(id);
+	public void undeploy(String appId) {
 		logger.debug("Undeploying module: {}", appId);
 
-		Map<String, String> selector = new HashMap<>();
-		selector.put(SPRING_APP_KEY, appId);
 		try {
-			client.services().withLabels(selector).delete();
-			client.replicationControllers().withLabels(selector).delete();
-			client.pods().withLabels(selector).delete();
+			if ("LoadBalancer".equals(client.services().withName(appId).get().getSpec().getType())) {
+				Service svc = client.services().withName(appId).get();
+				int tries = 0;
+				while (tries++ < 30) {
+					if (svc.getStatus().getLoadBalancer() != null &&
+							svc.getStatus().getLoadBalancer().getIngress() != null &&
+							svc.getStatus().getLoadBalancer().getIngress().isEmpty()) {
+						logger.debug("Waiting for LoadBalancer, try {}", tries);
+						try {
+							Thread.sleep(10000L);
+						} catch (InterruptedException e) {
+						}
+						svc = client.services().withName(appId).get();
+					} else {
+						break;
+					}
+				}
+				logger.debug("LoadBalancer Ingress: {}", svc.getStatus().getLoadBalancer().getIngress());
+			}
+			Boolean svcDeleted = client.services().withName(appId).delete();
+			logger.debug("Deleted service for: {} {}", appId, svcDeleted);
+			Boolean rcDeleted = client.replicationControllers().withName(appId).delete();
+			logger.debug("Deleted replication controller for: {} {}", appId, rcDeleted);
+			Map<String, String> selector = new HashMap<>();
+			selector.put(SPRING_APP_KEY, appId);
+			Boolean podDeleted = client.pods().withLabels(selector).delete();
+			logger.debug("Deleted pods for: {} {}", appId, podDeleted);
 		} catch (KubernetesClientException e) {
 			logger.error(e.getMessage(), e);
 			throw new RuntimeException(e);
@@ -126,13 +148,11 @@ public class KubernetesAppDeployer implements AppDeployer {
 	}
 
 	@Override
-	public AppStatus status(String id) {
-
-		String appId = fixKubeId(id);
+	public AppStatus status(String appId) {
 		Map<String, String> selector = new HashMap<>();
 		selector.put(SPRING_APP_KEY, appId);
 		PodList list = client.pods().withLabels(selector).list();
-		AppStatus status = buildModuleStatus(appId, list);
+		AppStatus status = buildAppStatus(appId, list);
 		logger.debug("Status for app: {} is {}", appId, status);
 
 		return status;
@@ -185,18 +205,22 @@ public class KubernetesAppDeployer implements AppDeployer {
 	}
 
 	private void createService(String appId, Map<String, String> idMap, int externalPort) {
+		ServiceSpecBuilder spec = new ServiceSpecBuilder();
+		if (properties.isCreateLoadBalancer()) {
+			spec.withType("LoadBalancer");
+		}
+		spec.withSelector(idMap)
+				.addNewPort()
+					.withPort(externalPort)
+				.endPort();
+
 		client.services().inNamespace(client.getNamespace()).createNew()
 				.withNewMetadata()
 					.withName(appId)
 					.withLabels(idMap)
 					.addToLabels(SPRING_MARKER_KEY, SPRING_MARKER_VALUE)
 					.endMetadata()
-				.withNewSpec()
-					.withSelector(idMap)
-					.addNewPort()
-						.withPort(externalPort)
-						.endPort()
-					.endSpec()
+				.withSpec(spec.build())
 				.done();
 	}
 
@@ -225,15 +249,11 @@ public class KubernetesAppDeployer implements AppDeployer {
 		else {
 			deploymentId = String.format("%s-%s", groupId, request.getDefinition().getName());
 		}
-		return fixKubeId(deploymentId);
-	}
-
-	private String fixKubeId(String id) {
 		// Kubernetes does not allow . in the name
-		return id.replace('.', '-');
+		return deploymentId.replace('.', '-');
 	}
 
-	private AppStatus buildModuleStatus(String id, PodList list) {
+	private AppStatus buildAppStatus(String id, PodList list) {
 		AppStatus.Builder statusBuilder = AppStatus.of(id);
 
 		if (list == null) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -30,7 +30,6 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -69,6 +69,11 @@ public class KubernetesAppDeployerProperties {
 	private String cpu = "500m";
 
 	/**
+	 * Environment variables to set for any deployed app container.
+	 */
+	private String[] environmentVariables = new String[]{};
+
+	/**
 	 * Maximum allowed restarts for app that fails due to an error or excessive resource use.
 	 */
 	private int maxTerminatedErrorRestarts = 2;
@@ -138,6 +143,14 @@ public class KubernetesAppDeployerProperties {
 
 	public void setCpu(String cpu) {
 		this.cpu = cpu;
+	}
+
+	public String[] getEnvironmentVariables() {
+		return environmentVariables;
+	}
+
+	public void setEnvironmentVariables(String[] environmentVariables) {
+		this.environmentVariables = environmentVariables;
 	}
 
 	public int getMaxTerminatedErrorRestarts() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -69,9 +69,14 @@ public class KubernetesAppDeployerProperties {
 	private String cpu = "500m";
 
 	/**
-	 * Environment variables to set for any deployed app container.
+	 * Environment variables to set for any deployed app container. To be used for service binding.
 	 */
 	private String[] environmentVariables = new String[]{};
+
+	/**
+	 * Create a "LoadBalancer" for the service created for each app. This facilitates assignment of external IP to app.
+	 */
+	private boolean createLoadBalancer = false;
 
 	/**
 	 * Maximum allowed restarts for app that fails due to an error or excessive resource use.
@@ -82,11 +87,6 @@ public class KubernetesAppDeployerProperties {
 	 * Maximum allowed restarts for app that is in a CrashLoopBackOff.
 	 */
 	private int maxCrashLoopBackOffRestarts = 4;
-
-	/**
-	 * Maximum allowed restarts for app that is in a CrashLoopBackOff.
-	 */
-	private boolean createLoadBalancer = false;
 
 
 	public String getImagePullSecret() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -87,6 +87,11 @@ public class KubernetesAppDeployerProperties {
 	private boolean createLoadBalancer = false;
 
 	/**
+	 * Time to wait for load balancer to be available before attempting delete of service (in minutes).
+	 */
+	private int minutesToWaitForService = 5;
+
+	/**
 	 * Maximum allowed restarts for app that fails due to an error or excessive resource use.
 	 */
 	private int maxTerminatedErrorRestarts = 2;
@@ -167,6 +172,14 @@ public class KubernetesAppDeployerProperties {
 
 	public void setEnvironmentVariables(String[] environmentVariables) {
 		this.environmentVariables = environmentVariables;
+	}
+
+	public int getMinutesToWaitForLoadBalancer() {
+		return minutesToWaitForService;
+	}
+
+	public void setMinutesToWaitForService(int minutesToWaitForService) {
+		this.minutesToWaitForService = minutesToWaitForService;
 	}
 
 	public int getMaxTerminatedErrorRestarts() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -25,6 +25,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.cloud.deployer.kubernetes")
 public class KubernetesAppDeployerProperties {
 
+	private static String KUBERNETES_NAMESPACE =
+			System.getenv("KUBERNETES_NAMESPACE") != null ? System.getenv("KUBERNETES_NAMESPACE") : "default";
+
+	/**
+	 * Namespace to use.
+	 */
+	private String namespace = KUBERNETES_NAMESPACE;
+
 	/**
 	 * Secrets for a access a private registry to pull images.
 	 */
@@ -35,7 +43,7 @@ public class KubernetesAppDeployerProperties {
 	 * should start checking its health status.
 	 */
 	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
-	private int livenessProbeDelay = 30;
+	private int livenessProbeDelay = 10;
 
 	/**
 	 * Timeout in seconds for the Kubernetes liveness check of the app container.
@@ -49,7 +57,7 @@ public class KubernetesAppDeployerProperties {
 	 * should start checking if the module is fully up and running.
 	 */
 	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
-	private int readinessProbeDelay = 20;
+	private int readinessProbeDelay = 10;
 
 	/**
 	 * Timeout in seconds that the app container has to respond to its
@@ -88,6 +96,14 @@ public class KubernetesAppDeployerProperties {
 	 */
 	private int maxCrashLoopBackOffRestarts = 4;
 
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
 
 	public String getImagePullSecret() {
 		return imagePullSecret;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -78,6 +78,12 @@ public class KubernetesAppDeployerProperties {
 	 */
 	private int maxCrashLoopBackOffRestarts = 4;
 
+	/**
+	 * Maximum allowed restarts for app that is in a CrashLoopBackOff.
+	 */
+	private boolean createLoadBalancer = false;
+
+
 	public String getImagePullSecret() {
 		return imagePullSecret;
 	}
@@ -148,5 +154,13 @@ public class KubernetesAppDeployerProperties {
 
 	public void setMaxCrashLoopBackOffRestarts(int maxCrashLoopBackOffRestarts) {
 		this.maxCrashLoopBackOffRestarts = maxCrashLoopBackOffRestarts;
+	}
+
+	public boolean isCreateLoadBalancer() {
+		return createLoadBalancer;
+	}
+
+	public void setCreateLoadBalancer(boolean createLoadBalancer) {
+		this.createLoadBalancer = createLoadBalancer;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
@@ -51,7 +51,7 @@ public class KubernetesAutoConfiguration {
 	@Bean
 	public TaskLauncher taskDeployer(KubernetesClient kubernetesClient,
 	                                 ContainerFactory containerFactory) {
-		// Return same instance for now, to satisfy server application wiring
+		// Return NO-OP instance for now, to satisfy server application wiring
 		return new KubernetesTaskLauncher();
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
@@ -57,7 +57,7 @@ public class KubernetesAutoConfiguration {
 
 	@Bean
 	public KubernetesClient kubernetesClient() {
-		return new DefaultKubernetesClient();
+		return new DefaultKubernetesClient().inNamespace(properties.getNamespace());
 	}
 
 	@Bean

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.deployer.spi.kubernetes;
 
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -34,7 +34,7 @@ import org.springframework.core.io.Resource;
 public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
 
 	@ClassRule
-	public static KubernetesTestSupport marathonAvailable = new KubernetesTestSupport();
+	public static KubernetesTestSupport kubernetesAvailable = new KubernetesTestSupport();
 
 	@Autowired
 	private AppDeployer appDeployer;

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
+import org.junit.ClassRule;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -30,6 +32,9 @@ import org.springframework.core.io.Resource;
  */
 @SpringApplicationConfiguration(classes = {KubernetesAutoConfiguration.class})
 public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
+
+	@ClassRule
+	public static KubernetesTestSupport marathonAvailable = new KubernetesTestSupport();
 
 	@Autowired
 	private AppDeployer appDeployer;

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTestSupport.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTestSupport.java
@@ -1,0 +1,54 @@
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.test.junit.AbstractExternalResourceTestSupport;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+/**
+ * JUnit {@link org.junit.Rule} that detects the fact that a Kubernetes installation is available.
+ *
+ * @author Thomas Risberg
+ */
+public class KubernetesTestSupport extends AbstractExternalResourceTestSupport<KubernetesClient> {
+
+	private ConfigurableApplicationContext context;
+
+
+	protected KubernetesTestSupport() {
+		super("KUBERNETES");
+	}
+
+	@Override
+	protected void cleanupResource() throws Exception {
+		context.close();
+	}
+
+	@Override
+	protected void obtainResource() throws Exception {
+		context = SpringApplication.run(Config.class);
+		resource = context.getBean(KubernetesClient.class);
+		resource.namespaces().list();
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@EnableConfigurationProperties(KubernetesAppDeployerProperties.class)
+	public static class Config {
+
+		@Autowired
+		private KubernetesAppDeployerProperties properties;
+
+		@Bean
+		public KubernetesClient kubernetesClient() {
+			return new DefaultKubernetesClient().inNamespace(properties.getNamespace());
+		}
+	}
+}


### PR DESCRIPTION
Fix SCDF deployment issues
    
- Add service env vars for RABBITMQ,KAFKA,ZK
    
- Fix deployment properties lookup for memory and cpu

Add "LoadBalancer" so app will be reachable from outside
    
- only create load balancer if property `spring.cloud.deployer.kubernetes.createLoadBalancer` is true
    
- we must wait for load balancer creation to be complete when deleting service
    
- updated fabric8 kubernetes-client version
